### PR TITLE
Add OctoLinker browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 
 ### Tools
 * [gitignore.io](https://github.com/joeblau/gitignore.io) - Create useful .gitignore files for your project [https://www.gitignore.io](https://www.gitignore.io).
+* [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through `projects.json` files efficiently with the OctoLinker browser extension for GitHub.
 
 ### Web Framework
 * [ReactJS.NET](https://github.com/reactjs/React.NET) - .NET library for JSX compilation and server-side rendering of React components.


### PR DESCRIPTION
[github.com/OctoLinker/browser-extension](https://github.com/OctoLinker/browser-extension)

Navigate through projects on GitHub.com efficiently with the OctoLinker browser extension.

Most projects consist of many files and third party dependencies. Files are referencing other files and / or dependencies by language specific statements like include or require. Dependencies are most likely declared in a file called manifest e.g. `package.json`, `project.json` or `Gemfile`. The OctoLinker browser extension makes these references clickable. No more copy and search.

## Demo

![dotnet](https://cloud.githubusercontent.com/assets/1393946/19506782/96134448-95ce-11e6-8cd7-3e608320a05a.gif)
