### PR TITLE
Adding .NET Core podcast of the Monsters

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 
 ## Videos
 * [Channel9](https://channel9.msdn.com)
+ * [ASP.NET Monsters](https://channel9.msdn.com/Series/aspnetmonsters)
 * [Visual Studio](https://www.youtube.com/user/VisualStudio/channels)
 * [.NET World](https://www.youtube.com/channel/UClW5uIyHKPhfSEloQxn7b0Q)
 


### PR DESCRIPTION
https://channel9.msdn.com/Series/aspnetmonsters

A twice-weekly show about ASP.NET Core MVC.