### PR TITLE
Add the Stubbery Api-stubbing library

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 * [nunit](https://github.com/nunit/dotnet-test-nunit) - NUnit test runner for .NET Core.
 * [shouldly](https://github.com/shouldly/shouldly) - Should testing for .NET - the way Asserting *Should* be! [http://shouldly.readthedocs.org/en/latest](http://shouldly.readthedocs.org/en/latest)
 * [SpecFlow](https://github.com/techtalk/SpecFlow/tree/DotNetCore) - Pragmatic BDD solution for .NET. It uses the Gherkin specification language and integrates to Visual Studio.
+* [Stubbery](https://markvincze.github.io/Stubbery/) - A simple library for creating and running Api stubs in .NET.
 * [TestStack.BDDfy](https://github.com/TestStack/TestStack.BDDfy) - The simplest BDD framework EVER!
 * [xunit](https://github.com/xunit/xunit) - Free, open source, community-focused unit testing tool for the .NET Framework.
 


### PR DESCRIPTION
Added Stubbery (https://markvincze.github.io/Stubbery/), which is a library for creating Api stubs, mainly for stubbing dependencies during integration testing.
It is a library I've been working on for a while now, it has mature documentation, and I've been already using it in production code. Also, I don't think there are other alternatives in .NET which provide the same functionality.