### PR TITLE
Add dotnet-win32-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 * [WampSharp](https://github.com/Code-Sharp/WampSharp) - C# implementation of [The Web Application Messaging Protocol](http://wamp-proto.org/) - Protocol that provides messaging patterns of Remote Procedure Calls and Publish/Subscribe over WebSockets.
 
 ### Windows Service
+* [dotnet-win32-service](https://github.com/dasMulli/dotnet-win32-service) - Set up and run as Windows Service directly from .NET Core.
 * [Topshelf](https://github.com/Topshelf/Topshelf) - Easy service hosting framework for building Windows services using .NET. `4.5.x or above`
 
 ## Starter Kits


### PR DESCRIPTION
Add the GitHub repo of `DasMulli.Win32.ServiceUtils` NuGet.
Since .NET Core currently has no `ServiceBase`, the classes in that package handle the necessary Windows Interop calls to run as windows service. Also has helper functions to create and delete windows services and works on Nano Server.
https://github.com/dasMulli/dotnet-win32-service