### PR TITLE
Add json:api implementations to APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
   * [graphql-dotnet](https://github.com/graphql-dotnet/graphql-dotnet) - GraphQL for .NET.
   * [FSharp.Data.GraphQL](https://github.com/fsprojects/FSharp.Data.GraphQL) - FSharp implementation of Facebook GraphQL query language [https://fsprojects.github.io/FSharp.Data.GraphQL](https://fsprojects.github.io/FSharp.Data.GraphQL).
   * [parser](https://github.com/graphql-dotnet/parser) - A lexer and parser for GraphQL in .NET.
+* [JSON API .Net Core](https://github.com/Research-Institute/json-api-dotnet-core) - Framework for building json:api compliant APIs with the goal of eliminating RESTful boilerplate
 
 ### Application Frameworks
 * [ABP](https://github.com/aspnetboilerplate/aspnetboilerplate) - ASP.NET Boilerplate is a general purpose application framework especially designed for new modern web applications. It uses already familiar tools and implements best practices arround them to provide you a SOLID development experience.


### PR DESCRIPTION
[json:api](http://jsonapi.org/) is comparable to GraphQL and deserves equal representation. I have included two server implementations:
- [JSON API .Net Core](https://github.com/Research-Institute/json-api-dotnet-core) maintained by myself
- [NJsonApiCore](https://github.com/brainwipe/NJsonApiCore) maintained by @brainwipe
