### PR TITLE
Add Slack to community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 * [ASP.NET](https://forums.asp.net)
 * [.NET Foundation](http://forums.dotnetfoundation.org)
 * [Channel9](https://channel9.msdn.com/Forums)
+* [Slack](http://tattoocoder.com/aspnet-slack-sign-up)
 * Stack Overflow
   *  [.NET Core](https://stackoverflow.com/questions/tagged/.net-core)
   *  [CoreCLR](https://stackoverflow.com/questions/tagged/coreclr)


### PR DESCRIPTION
Awesome collection, thanks a bunch!

Adding slack since it's quite active and a lot of developers from the community (twitter, github etc.) are active there.