### PR TITLE
Add posh-dotnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 * [letsencrypt-win-simple](https://github.com/Lone-Coder/letsencrypt-win-simple) - A Simple ACME Client for Windows.
 * [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through `projects.json` files efficiently with the OctoLinker browser extension for GitHub.
 * [Opserver](https://github.com/opserver/Opserver) - Stack Exchange's Monitoring System.
+* [posh-dotnet](https://github.com/bergmeister/posh-dotnet) - `PowerShell` tab completion for the [dotnet CLI](https://github.com/dotnet/cli).
 * [ShareX](https://github.com/ShareX/ShareX) - Free and open source program that lets you capture or record any area of your screen and share it with a single press of a key. It also allows uploading images, text or other types of files to over 80 supported destinations you can choose from. [https://getsharex.com](https://getsharex.com)
 * [X.Web.Sitemap](https://github.com/dncuug/X.Web.Sitemap) – Simple sitemap generator for .NET and .NET Core
 * [X.Web.RSS](https://github.com/dncuug/X.Web.RSS) – Simple RSS Feed generator for .NET and .NET Core


### PR DESCRIPTION
[posh-dotnet](https://github.com/bergmeister/posh-dotnet) adds `PowerShell` tab completion for the [dotnet CLI](https://github.com/dotnet/cli) (for version 1 and  2 with version 2 being much more enhanced)