### PR TITLE
Add Ben.Demystifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 * [Stripe](https://github.com/ServiceStack/Stripe) - Typed .NET clients for stripe.com REST APIs.
 
 ### Exceptions
+* [Ben.Demystifier](https://github.com/benaadams/Ben.Demystifier) - High performance understanding for stack traces (Make error logs more productive)
 * [Exceptionless](https://github.com/exceptionless/Exceptionless.Net) - Exceptionless .NET Client
 
 ### Functional Programming


### PR DESCRIPTION
[Ben.Demystifier](https://github.com/benaadams/Ben.Demystifier)
.NET stack traces output the compiler transformed methods; rather than the source code methods, which make them slow to mentally parse and match back to the source code.
This library output the modern C# 7.0 features in stack traces in an understandable fashion that looks like the source code that generated them.