### PR TITLE
Add Fake JSON Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 * [docfx](https://github.com/dotnet/docfx) - Tools for building and publishing API documentation for .NET projects [http://dotnet.github.io/docfx](http://dotnet.github.io/docfx)
 * [dotnetfiddle](https://dotnetfiddle.net) - .NET sandbox for developers to quickly try out code and share code snippets.
 * [EntryPoint](https://github.com/Nick-Lucas/EntryPoint) - Composable CLI (Command Line) Argument Parser for .Net Core & .Net Framework 4.5+.
+* [Fake JSON Server](https://github.com/ttu/dotnet-fake-json-server) - Fake REST API for prototyping or as a CRUD Back End. No need to define types, uses dynamic typing. Data is stored to a single JSON file. Has authentication, WebSocket notifications, async long running operations, random generation for errors/delays and experimental GraphQL support.
 * [gitignore.io](https://github.com/joeblau/gitignore.io) - Create useful .gitignore files for your project [https://www.gitignore.io](https://www.gitignore.io).
 * [GitInfo](https://github.com/kzu/GitInfo) - Git and SemVer Info from MSBuild, C# and VB.
 * [ICanHasDotnetCore](https://github.com/OctopusDeploy/ICanHasDotnetCore) - Scans uploaded packages.config files or GitHub repository and determines whether the nuget packages target .NET Standard [https://icanhasdot.net](https://icanhasdot.net).


### PR DESCRIPTION
Fake JSON Server - [https://github.com/ttu/dotnet-fake-json-server](https://github.com/ttu/dotnet-fake-json-server)

Fake JSON Server is a Fake REST API for prototyping or as a CRUD Back End. No need to define types as it uses dynamic typing. Data is stored to a easily editable single JSON file. Has authentication (Token & Basic), WebSocket notifications for updates, async long running operations, configurable random generation for errors/delays and experimental GraphQL support. REST API follows best practices from multiple guides.

Uses .NET Core 2.0 and can be used in Win/macOS/Linux without installing .NET Core by using self-contained deployment packages (https://github.com/ttu/dotnet-fake-json-server#self-contained-application) or Docker.


I added this to Tools section as awesmome-dotnet repository has this also under [Tools](https://github.com/quozd/awesome-dotnet#tools). 
