### PR TITLE
Add CurlThin

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 * [warden-stack](https://github.com/warden-stack) - "health checks" for your applications, resources and infrastructure. Keep your Warden on the watch.
 
 ### Networking
+* [CurlThin](https://github.com/stil/CurlThin) - Lightweight cURL binding library for C# with support for multiple simultaneous transfers through curl_multi interface.
 * [NETStandard.HttpListener](https://github.com/StefH/NETStandard.HttpListener) - HttpListener for .NET Core (NETStandard).
 
 ### ORM


### PR DESCRIPTION
Library: https://github.com/stil/CurlThin

It's a binding library against very popular libcurl, but this time with support for parallel processing using curl_multi interface.
Using CurlThin instead of .NET built-in HttpClient allows for more fine-grained control over sending HTTP (and other types) of requests.
For example we can get detailed error messages, use many kinds of proxies etc.

libcurl is very, very portable and runs identically on ton of platforms, including of course Win, Mac and Linux.

CurlThin includes several code samples and I'd be happy to continue it's development by covering more use cases than just my own ones.