### PR TITLE
Add ether network library

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 * [RService.io](https://github.com/Stoom/RService.IO) - ASP.Net Core RESTful microservice framework that focusing on speed and ease of use.
 * [ServiceStack](https://github.com/ServiceStack/ServiceStack) - Thoughtfully architected, obscenely fast, thoroughly enjoyable web services for all [https://servicestack.net](https://servicestack.net).
 * [Steeltoe OSS](https://github.com/SteelToeOSS) - .NET toolkit for common microservice patterns.
+* [Ether.Network](https://github.com/Eastrall/Ether.Network) - Ether.Network is an open source networking library that allow developers to create simple, fast and scalable socket server or client applications over the TCP/IP protocol.
 
 ### Application Templates
 * [ASP.NET Core Boilerplate](https://github.com/ASP-NET-Core-Boilerplate/Templates) - A professional ASP.NET MVC template for building secure, fast, robust and adaptable web applications or sites. It provides the minimum amount of code required on top of the default MVC template provided by Microsoft.


### PR DESCRIPTION
Application Frameworks/Ether.Network - [https://github.com/Eastrall/Ether.Network](https://github.com/Eastrall/Ether.Network)

Ether Network is a C# networking library built with the .NET Core Framework (NetStandard 1.3 and 2.0) and also compatible with the .NET Framework 4.5 and 4.6. It allows you to create simple, scalable and fast client or server applications very easily.
It provides classes to create your TCP server or client with only a few lines of code, and also a packet builder that allows you toa create your messages very easily.