### PR TITLE
Added entry for the new Channel9 youtube channel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,8 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 * [The little ASP.NET Core](https://www.recaffeinate.co/book)
 
 ## Videos
-* [Channel9](https://channel9.msdn.com)
+* [Channel9](https://channel9.msdn.com) - MSDN
+* [Channel9](https://www.youtube.com/channel/UCsMica-v34Irf9KVTh6xx-g) - YouTube
  * [ASP.NET Monsters](https://channel9.msdn.com/Series/aspnetmonsters)
 * [Visual Studio](https://www.youtube.com/user/VisualStudio/channels)
 


### PR DESCRIPTION
Channel9 is now available on YouTube, in addition to the existing MSDN site. This adds a link, and clarification regarding the host next to both Channel9 links under Videos.

Channel9 is listed again under Community, but 1 youtube entry is probably fine.