### PR TITLE
Added dotnet cli cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 * [Sample Projects](#sample-projects)
 * [Articles](#articles)
 * [Books](#books)
+* [Cheat Sheets](#cheat-sheets)
 * [Videos](#videos)
 * [Podcasts](#podcasts)
 * [Community](#community)
@@ -708,6 +709,9 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 * [Microservices in .NET Core: with C#, the Nancy framework, and OWIN middleware](https://www.amazon.com/Microservices-NET-Core-framework-middleware/dp/1617293377)
 * [Professional C# 6 and .NET Core 1.0](https://www.amazon.com/Professional-NET-Core-Christian-Nagel/dp/111909660X)
 * [The little ASP.NET Core](https://www.recaffeinate.co/book)
+
+## Cheat Sheets
+* [dotnet cli Cheat Sheet](http://en.otomatikmuhendis.com/2018/07/02/cheat-sheet-for-dotnet-cli/)
 
 ## Videos
 * [Channel9](https://channel9.msdn.com) - MSDN


### PR DESCRIPTION
I created a cheat sheet for dotnet cli and I wanted to add it to the list but I couldn't find any suitable section. So I added "Cheat Sheets" section as well.

http://en.otomatikmuhendis.com/2018/07/02/cheat-sheet-for-dotnet-cli/