### PR TITLE
Removed discontinued library aspnetcore-health

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Thanks to all [contributors](https://github.com/thangchung/awesome-dotnet-core/g
 * [nodatime](https://github.com/nodatime/nodatime) - Better date and time API for .NET [http://nodatime.org](http://nodatime.org).
 
 ### Distributed Computing
-* [aspnetcore-health](https://github.com/lurumad/aspnetcore-health) - Enables load balancers to monitor the status of deployed Web applications.
+* [BeatPulse](https://github.com/Xabaril/BeatPulse) - Enable load balancers to montior the status of deployed Web applications
 * [Foundatio](https://github.com/exceptionless/Foundatio) - Pluggable foundation blocks for building distributed apps.
 * [Rafty](https://github.com/ThreeMammals/Rafty) - RAFT consensus in .NET Core.
 * [Obvs](https://github.com/christopherread/Obvs) - An observable microservice bus .NET library that wraps the underlying transport in simple Rx based interfaces.


### PR DESCRIPTION
Beat pulse (https://github.com/Xabaril/BeatPulse) supports dotnet core 2.1 and aspnetcore-health is discontinued in favor of BeatPulse. More info on https://github.com/lurumad/aspnetcore-health.