### PR TITLE
Add "dotnetcore-microservices-poc" to sample projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,7 @@ Check out my [blog](https://medium.com/@thangchung) or say hi on [Twitter](https
   * [coolstore-microservices ](https://github.com/vietnam-devs/coolstore-microservices) - A containerised polyglot Service Mesh application (Istio) consisting of microservices based on .NET Core, NodeJS and more running on Kubernetes.
   * [distributed-playground](https://github.com/jvandevelde/distributed-playground) - Distributed service playground with Vagrant, Consul, Docker & ASP.NET Core.
   * [DNC-DShop](https://github.com/devmentors) - Distributed .NET Core project and free course. (DDD, CQRS, RabbitMQ, MongoDB, Redis, Monitoring, Logging, CI, CD)
+  * [dotnetcore-microservices-poc](https://github.com/asc-lab/dotnetcore-microservices-poc) -  simplified insurance sales system made in a microservices architecture using .NET Core (EF Core, MediatR, Marten, Eureka, Ocelot, RabbitMQ, Polly, ElasticSearch, Dapper) with blog post series.
   * [eShopOnContainers](https://github.com/dotnet/eShopOnContainers) - Microservices Architecture and Containers based Reference Application.
   * [magazine-website](https://github.com/thangchung/magazine-website) - Magazine website (using .NET Core, ASP.NET Core, EF Core) with DDD, CQRS, microservices, asynchronous programming applied.
   * [microservices-in-dotnetcore](https://github.com/horsdal/microservices-in-dotnetcore) - The code sample from my microservices book -[https://manning.com/books/microservices-in-net-core](https://manning.com/books/microservices-in-net-core)


### PR DESCRIPTION
Link to project: https://github.com/asc-lab/dotnetcore-microservices-poc

In my opinion this example is very useful for devs, who wants to try some microservices stack on .NET Core. The project is accompanied by a whole series of blog posts describing the techniques and technologies used.

- [Part I The Plan](https://altkomsoftware.pl/en/blog/building-microservices-on-net-core-1/)
- [Part 2 Shaping microservice internal architecture with CQRS and MediatR](https://altkomsoftware.pl/en/blog/microservices-net-core-cqrs-mediatr/)
- [Part 3 Service Discovery with Eureka](https://altkomsoftware.pl/en/blog/service-discovery-eureka/)
- [Part 4 Building API Gateways With Ocelot](https://altkomsoftware.pl/en/blog/building-api-gateways-with-ocelot/)

Next parts (work in progress):
- Part 5 Marten An Ideal Repository For Your Domain Aggregates
- Part 6 Chat with SignalR
- Part 7 Async Communication with RabbitMQ
- Part 8 Sales Stats Dashboard with ElasticSearch and ChartJS