### PR TITLE
Change lz4net link

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Check out my [blog](https://medium.com/@thangchung) or say hi on [Twitter](https
   	* [Prometheus.Client.HttpRequestDurations](https://github.com/PrometheusClientNet/Prometheus.Client.HttpRequestDurations) -  Metrics logging of request durations for the Prometheus.Client.
 
 ### Compression
-* [lz4net](https://github.com/MiloszKrajewski/lz4net) - Ultra fast compression algorithm for all .NET platforms.
+* [lz4net](https://github.com/MiloszKrajewski/K4os.Compression.LZ4) - Ultra fast compression algorithm for all .NET platforms.
 * [sharpcompress](https://github.com/adamhathcock/sharpcompress) - Fully managed C# library to deal with many compression types and formats.
 
 ### Compilers, Transpilers and Languages


### PR DESCRIPTION
The Compression lz4net is replaced by [K4os.Compression.LZ4](https://github.com/MiloszKrajewski/K4os.Compression.LZ4 )

![](http://image.acmx.xyz/lindexi%2F20194275610193)