### PR TITLE
Add a 'SPAs' subcategory in 'Sample Projects'

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,6 +824,8 @@ Follows best practices and conventions to provide you a SOLID development experi
   * [Practical ASP.NET Core](https://github.com/dodyg/practical-aspnetcore) - A daily updated micro samples of ASP.NET Core features and facilities.
   * [Sample .NET Core CQRS REST API](https://github.com/kgrzybek/sample-dotnet-core-cqrs-api) - .NET Core REST API CQRS implementation with raw SQL and DDD using Clean Architecture.
   * [StarWars](https://github.com/JacekKosciesza/StarWars) - GraphQL 'Star Wars' example using GraphQL for .NET, ASP.NET Core, Entity Framework Core.
+* SPAs
+  * [Blazing Pizza workshop](https://aka.ms/blazorworkshop) - Pizza ordering website build with Blazor, a single-page app framework for building client-side web apps using .NET and WebAssembly.
  
 ## Articles
 * Basic knowledge


### PR DESCRIPTION
- Add a 'SPAs' subcategory in the 'Sample Projects' section to list the Single-Page application samples.
- Add a link to the 'Blazing Pizza workshop', the workshop by Microsoft to build a complete website from scratch with Blazor.