### PR TITLE
Remove StructureMap, Replaced by lamar

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,10 +433,10 @@ Follows best practices and conventions to provide you a SOLID development experi
 * [DryIoc](https://github.com/dadhi/DryIoc) - Fast, small, full-featured IoC Container for .NET.
 * [Grace](https://github.com/ipjohnson/Grace) - Grace is a feature rich Dependency Injection Container designed with ease of use and performance in mind.
 * [Inyector](https://github.com/davidrevoledo/Inyector) - Dependency Injection Automation for AspNetCore 
+* [Lamar](https://github.com/jasperfx/lamar) - Dependency Injection/Inversion of Control tool for .NET. (Previously StructureMap)
 * [LightInject](https://github.com/seesharper/LightInject) - Ultra lightweight IoC container [http://www.lightinject.net](http://www.lightinject.net).
 * [SimpleInjector](https://github.com/simpleinjector/SimpleInjector) - Easy, flexible, and fast Dependency Injection library that promotes best practice to steer developers towards the pit of success.
 * [Stashbox](https://github.com/z4kn4fein/stashbox) - A lightweight, portable dependency injection framework for .NET based solutions.
-* [lamar](https://github.com/jasperfx/lamar) - Dependency Injection/Inversion of Control tool for .NET. (Previously StructureMap)
 
 ### Logging
 * [common-logging](https://github.com/net-commons/common-logging) - Portable logging abstraction for .NET [http://net-commons.github.io/common-logging](http://net-commons.github.io/common-logging).

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 * [LightInject](https://github.com/seesharper/LightInject) - Ultra lightweight IoC container [http://www.lightinject.net](http://www.lightinject.net).
 * [SimpleInjector](https://github.com/simpleinjector/SimpleInjector) - Easy, flexible, and fast Dependency Injection library that promotes best practice to steer developers towards the pit of success.
 * [Stashbox](https://github.com/z4kn4fein/stashbox) - A lightweight, portable dependency injection framework for .NET based solutions.
-* [StructureMap](https://github.com/structuremap/structuremap) - Dependency Injection/Inversion of Control tool for .NET.
+* [lamar](https://github.com/jasperfx/lamar) - Dependency Injection/Inversion of Control tool for .NET. (Previously StructureMap)
 
 ### Logging
 * [common-logging](https://github.com/net-commons/common-logging) - Portable logging abstraction for .NET [http://net-commons.github.io/common-logging](http://net-commons.github.io/common-logging).


### PR DESCRIPTION
According to: https://github.com/structuremap/structuremap is not maintain anymore "StructureMap has been sunsetted"
Replace by https://github.com/jasperfx/lamar