### PR TITLE
Please Add - Basic Scheme Authentication for ASP.NET Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 
 ### Authentication and Authorization
 * [AspNet.Security.OpenIdConnect.Server](https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server) - OpenID Connect/OAuth2 server framework for OWIN/Katana and ASP.NET Core.
-* [AspNetCore.Authentication.Basic](https://github.com/mihirdilip/aspnetcore-authentication-basic) - Basic Scheme Authentication for ASP.NET Core
+* [aspnetcore-authentication-basic](https://github.com/mihirdilip/aspnetcore-authentication-basic) - Basic Scheme Authentication for ASP.NET Core
 * [Auth0](https://github.com/auth0/auth0.net) - Hosted, enterprise-grade platform for modern identity.
 * [Casbin.NET](https://github.com/casbin-net/Casbin.NET) - Authorization library that supports access control models like ACL, RBAC, ABAC in C#
 * [Cierge](https://github.com/PwdLess/Cierge) - Cierge is an OpenID Connect server that handles user signup, login, profiles, management, social logins, and more. Instead of storing passwords, Cirege uses magic links/codes and external logins to authenticate your users.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 * [stormpath-sdk](https://github.com/stormpath/stormpath-sdk-dotnet) - Build [simple, secure web applications](https://github.com/stormpath/stormpath-aspnetcore) with Stormpath and ASP.NET Core. 
 * [stormpath-sdk](https://github.com/stormpath/stormpath-sdk-dotnet) - Build [simple, secure web applications](https://github.com/stormpath/stormpath-aspnetcore) with Stormpath and ASP.NET Core.(Deprecated: It will longer get updated as of March 2017 after joining OKTA) 
 * [stuntman](https://github.com/ritterim/stuntman) - Library for impersonating users during development leveraging ASP.NET Identity.
+* [Mihir.AspNetCore.Authentication.Basic](https://github.com/mihirdilip/Mihir.AspNetCore.Authentication.Basic) - Basic Scheme Authentication for ASP.NET Core
 
 ### Blockchain
 * [BTCPayServer](https://github.com/btcpayserver/btcpayserver) - A cross platform, self-hosted server compatible with Bitpay API.

--- a/README.md
+++ b/README.md
@@ -193,12 +193,12 @@ Follows best practices and conventions to provide you a SOLID development experi
   * [IdentityServer4.MongoDB](https://github.com/diogodamiani/IdentityServer4.MongoDB) - MongoDB persistence layer
   * [IdentityServer4.EntityFrameworkCore](https://github.com/2020IP/TwentyTwenty.IdentityServer4.EntityFrameworkCore) - Entity Framework Core persistence layer
   * [IdentityServer4.Templates](https://github.com/IdentityServer/IdentityServer4.Templates) - dotnet cli templates for IdentityServer4.
+* [Mihir.AspNetCore.Authentication.Basic](https://github.com/mihirdilip/Mihir.AspNetCore.Authentication.Basic) - Basic Scheme Authentication for ASP.NET Core
 * [openiddict](https://github.com/openiddict/openiddict-core) - Easy-to-use OpenID Connect server for ASP.NET Core.
   * [oidc-debugger](https://github.com/nbarbettini/oidc-debugger) - OAuth 2.0 and OpenID Connect debugging tool.
 * [stormpath-sdk](https://github.com/stormpath/stormpath-sdk-dotnet) - Build [simple, secure web applications](https://github.com/stormpath/stormpath-aspnetcore) with Stormpath and ASP.NET Core. 
 * [stormpath-sdk](https://github.com/stormpath/stormpath-sdk-dotnet) - Build [simple, secure web applications](https://github.com/stormpath/stormpath-aspnetcore) with Stormpath and ASP.NET Core.(Deprecated: It will longer get updated as of March 2017 after joining OKTA) 
 * [stuntman](https://github.com/ritterim/stuntman) - Library for impersonating users during development leveraging ASP.NET Identity.
-* [Mihir.AspNetCore.Authentication.Basic](https://github.com/mihirdilip/Mihir.AspNetCore.Authentication.Basic) - Basic Scheme Authentication for ASP.NET Core
 
 ### Blockchain
 * [BTCPayServer](https://github.com/btcpayserver/btcpayserver) - A cross platform, self-hosted server compatible with Bitpay API.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 
 ### Authentication and Authorization
 * [AspNet.Security.OpenIdConnect.Server](https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server) - OpenID Connect/OAuth2 server framework for OWIN/Katana and ASP.NET Core.
+* [AspNetCore.Authentication.Basic](https://github.com/mihirdilip/aspnetcore-authentication-basic) - Basic Scheme Authentication for ASP.NET Core
 * [Auth0](https://github.com/auth0/auth0.net) - Hosted, enterprise-grade platform for modern identity.
 * [Casbin.NET](https://github.com/casbin-net/Casbin.NET) - Authorization library that supports access control models like ACL, RBAC, ABAC in C#
 * [Cierge](https://github.com/PwdLess/Cierge) - Cierge is an OpenID Connect server that handles user signup, login, profiles, management, social logins, and more. Instead of storing passwords, Cirege uses magic links/codes and external logins to authenticate your users.
@@ -193,7 +194,6 @@ Follows best practices and conventions to provide you a SOLID development experi
   * [IdentityServer4.MongoDB](https://github.com/diogodamiani/IdentityServer4.MongoDB) - MongoDB persistence layer
   * [IdentityServer4.EntityFrameworkCore](https://github.com/2020IP/TwentyTwenty.IdentityServer4.EntityFrameworkCore) - Entity Framework Core persistence layer
   * [IdentityServer4.Templates](https://github.com/IdentityServer/IdentityServer4.Templates) - dotnet cli templates for IdentityServer4.
-* [Mihir.AspNetCore.Authentication.Basic](https://github.com/mihirdilip/Mihir.AspNetCore.Authentication.Basic) - Basic Scheme Authentication for ASP.NET Core
 * [openiddict](https://github.com/openiddict/openiddict-core) - Easy-to-use OpenID Connect server for ASP.NET Core.
   * [oidc-debugger](https://github.com/nbarbettini/oidc-debugger) - OAuth 2.0 and OpenID Connect debugging tool.
 * [stormpath-sdk](https://github.com/stormpath/stormpath-sdk-dotnet) - Build [simple, secure web applications](https://github.com/stormpath/stormpath-aspnetcore) with Stormpath and ASP.NET Core. 

--- a/contributing.md
+++ b/contributing.md
@@ -5,7 +5,6 @@
 * Use the following format: \[LIBRARY\]\(LINK\) - DESCRIPTION
 * The link should be the name of the package or project
 * Keep descriptions concise, clear and simple
-* Make sure the alphabetical order is maintained 
 * New categories, or improvements to the existing ones are also welcome
 
 ## Pull requests workflow

--- a/contributing.md
+++ b/contributing.md
@@ -5,6 +5,7 @@
 * Use the following format: \[LIBRARY\]\(LINK\) - DESCRIPTION
 * The link should be the name of the package or project
 * Keep descriptions concise, clear and simple
+* Make sure the alphabetical order is maintained 
 * New categories, or improvements to the existing ones are also welcome
 
 ## Pull requests workflow


### PR DESCRIPTION
Added aspnetcore-authentication-basic - Basic Scheme Authentication for ASP.NET Core to Authentication and Authorization. It is useful for setting up a quick basic authentication for an ASP.NET Core app.

Download directly from https://www.nuget.org/packages/AspNetCore.Authentication.Basic
Or by running the below command on your project.
PM> Install-Package AspNetCore.Authentication.Basic

This package used to be Mihir.AspNetCore.Authentication.Basic (https://www.nuget.org/packages/Mihir.AspNetCore.Authentication.Basic) which has now been deprecated and moved to AspNetCore.Authentication.Basic (https://www.nuget.org/packages/AspNetCore.Authentication.Basic).

Please let me know if you have any queries.