### PR TITLE
Add Synapses to Machine Learning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,8 @@ Follows best practices and conventions to provide you a SOLID development experi
 * [Spreads](https://github.com/Spreads/Spreads/) - Series and Panels for Real-time and Exploratory Analysis of Data Streams.
 * [TensorFlowSharp](https://github.com/migueldeicaza/TensorFlowSharp) - TensorFlow API for .NET languages.
 * [WaveFunctionCollapse](https://github.com/mxgmn/WaveFunctionCollapse) - itmap & tilemap generation from a single example with the help of ideas from quantum mechanics.
-* [SiaNet](https://github.com/SciSharp/SiaNet) - A C# deep learning library, human friendly, CUDA/OpenCL supported, well structured, easy to extend 
+* [SiaNet](https://github.com/SciSharp/SiaNet) - A C# deep learning library, human friendly, CUDA/OpenCL supported, well structured, easy to extend
+* [Synapses](https://mrdimosthenis.github.io/Synapses) - A lightweight Neural Network library, for js, jvm and .net.
 
 ### Mail
 * [FluentEmail](https://github.com/lukencode/FluentEmail) - All in one email sender for .NET and .NET Core


### PR DESCRIPTION
Synapses is a lightweight Neural Network library, for js, jvm and .net.
https://mrdimosthenis.github.io/Synapses
Two versions of the library published on nuget. Synapses for F# and SynapsesCSharp.