### PR TITLE
Add Onff - Simple feature toggling library

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 * [NReco.LambdaParser](https://github.com/nreco/lambdaparser) - Parses string expressions (formulas, methods calls, conditions) to LINQ expression tree that can be compiled to lambda and evaluated.
 * [NuGet Trends](https://github.com/NuGetTrends/nuget-trends) - Website with statistics of NuGet packages download count.
 * [NYoutubeDL](https://gitlab.com/BrianAllred/NYoutubeDL) - A simple youtube-dl library for C#/.NET.
+* [Onff](https://github.com/moattarwork/onff) - Simple feature toggling for ASP.Net Core
 * [Otp.NET](https://github.com/kspearrin/Otp.NET) - An implementation TOTP RFC 6238 and HOTP RFC 4226 in C#.
 * [pose](https://github.com/tonerdo/pose) - Replace any .NET method (including static and non-virtual) with a delegate
 * [PuppeteerSharp](https://github.com/kblok/puppeteer-sharp) - Puppeteer Sharp is a .NET port of the official Node.JS Puppeteer API.


### PR DESCRIPTION
Onff is a library to facilitate the feature toggling for .Net Core projects. It's really easy to use and very minimalistic