### PR TITLE
added my library to the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Follows best practices and conventions to provide you a SOLID development experi
   * [IdentityServer4.Templates](https://github.com/IdentityServer/IdentityServer4.Templates) - dotnet cli templates for IdentityServer4.
 * [openiddict](https://github.com/openiddict/openiddict-core) - Easy-to-use OpenID Connect server for ASP.NET Core.
   * [oidc-debugger](https://github.com/nbarbettini/oidc-debugger) - OAuth 2.0 and OpenID Connect debugging tool.
+* [Solrevdev.InstagramBasicDisplay](https://github.com/solrevdev/instagram-basic-display) - A netstandard2.0 library that consumes the new Instagram Basic Display API.
 * [stormpath-sdk](https://github.com/stormpath/stormpath-sdk-dotnet) - Build [simple, secure web applications](https://github.com/stormpath/stormpath-aspnetcore) with Stormpath and ASP.NET Core. 
 * [stormpath-sdk](https://github.com/stormpath/stormpath-sdk-dotnet) - Build [simple, secure web applications](https://github.com/stormpath/stormpath-aspnetcore) with Stormpath and ASP.NET Core.(Deprecated: It will longer get updated as of March 2017 after joining OKTA) 
 * [stuntman](https://github.com/ritterim/stuntman) - Library for impersonating users during development leveraging ASP.NET Identity.


### PR DESCRIPTION
https://github.com/solrevdev/instagram-basic-display 

A netstandard2.0 library that consumes the new Instagram Basic Display API.

Also includes a Razor Pages Web example that shows how to use the library and a Static site example that shows how to consume the new Instagram Basic Display API with just vanilla JavaScript.