### PR TITLE
Update OctoLinker link & description

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,7 +785,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 * [NuKeeper](https://github.com/NuKeeperDotNet/NuKeeper) - Automagically update nuget packages in .NET projects.
 * [NuGetPackageExplorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer) - Create, update and deploy Nuget Packages with a GUI.
 * [NugetVisualizer](https://github.com/sepharg/NugetVisualizer) - Visualize all of the nuget packages and their corresponding versions for a set of given git repositories or folders.
-* [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through `projects.json` files efficiently with the OctoLinker browser extension for GitHub.
+* [OctoLinker](https://github.com/OctoLinker/OctoLinker) - Navigate through `project.json`, `packages.config`, `*.props`, `*.targets`, and C#/F#/VB.NET project files efficiently with the OctoLinker browser extension for GitHub.
 * [posh-dotnet](https://github.com/bergmeister/posh-dotnet) - `PowerShell` tab completion for the [dotnet CLI](https://github.com/dotnet/cli).
 * [Rin](https://github.com/mayuki/Rin) - Request/response Inspector middleware for ASP.NET Core. like Glimpse.
 * [scoop](https://github.com/lukesampson/scoop) - A command-line installer for Windows.


### PR DESCRIPTION
Recently a bunch of new .net support was added to OctoLinker for:

- `dotnet-tools.json` (local tool configs)
- `packages.config`
- `Directory.Build.props`
- `Directory.Build.targets`
- `*.csproj`, `*.fsproj`, and `*.vbproj` files

The project files, `*.props`, and `*.targets` files support `PackageReference` as well as `Compile`, `Content`, `EmbeddedResource`, `None`, `DotNetCliToolReference`, and `FrameworkReference` elements.

Support for [Paket](https://fsprojects.github.io/Paket/) is in the works and will hopefully be in the next release.

/cc @stefanbuck