### PR TITLE
Added elmah.io to exceptions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 
 ### Exceptions
 * [Demystifier](https://github.com/benaadams/Ben.Demystifier) - High performance understanding for stack traces (Make error logs more productive).
+* [elmah.io](https://github.com/elmahio/Elmah.Io.Client) - .NET client for elmah.io. elmah.io is error logging and uptime monitoring for .NET developers with great support for ASP.NET Core too.
 * [Exceptionless](https://github.com/exceptionless/Exceptionless.Net) - Exceptionless .NET Client
 * [GlobalExceptionHandlerDotNet](https://github.com/JosephWoodward/GlobalExceptionHandlerDotNet) - GlobalExceptionHandlerDotNet allows you to configure exception handling as a convention with your ASP.NET Core application pipeline as opposed to explicitly handling them within each controller action.
 * [Sentry](https://github.com/getsentry/sentry-dotnet) - .NET SDK for Sentry, an Open-source error tracking that helps developers monitor and fix crashes in real time.


### PR DESCRIPTION
Adding elmah.io to the list of Exceptions tools alongside similar tools like Sentry. The added link is for https://github.com/elmahio/Elmah.Io.Client which is for the general .NET (netstandard) client for communicating with elmah.io. Not sure if it would be better to add the client for ASP.NET Core (https://github.com/elmahio/Elmah.Io.AspNetCore). I have chosen the general client since I guess this list is not specifically for ASP.NET Core 👍