### PR TITLE
Fixed hyperlink to project 'dotnet-outdated' & updated project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 * [DinkToPdf](https://github.com/rdvojmoc/DinkToPdf) - C# .NET Core wrapper for wkhtmltopdf library that uses Webkit engine to convert HTML pages to PDF.
 * [dotnet-env](https://github.com/tonerdo/dotnet-env) - A .NET library to load environment variables from .env files.
 * [DotNet.Glob](https://github.com/dazinator/DotNet.Glob) - A fast globbing library for .NET / .NETStandard applications. Outperforms Regex.
-* [Dotnet outdated](https://github.com/jerriep/dotnet-outdated) - A .NET Core global tool to display outdated NuGet packages in a project.
+* [Dotnet outdated](https://github.com/dotnet-outdated/dotnet-outdated) - A .NET Core global tool to display and update outdated NuGet packages in a project
 * [Dotnet Script](https://github.com/filipw/dotnet-script) - Run C# scripts from the .NET CLI.
 * [Dotnet Serve](https://github.com/natemcmaster/dotnet-serve) - Simple command-line HTTP server for .NET Core CLI.
 * [Eighty](https://github.com/benjamin-hodgson/Eighty) - A simple HTML generation library


### PR DESCRIPTION
The current hyperlink of the project 'dotnet-outdated' is not reachable anymore:
<img width="1040" alt="404" src="https://user-images.githubusercontent.com/21332313/123537785-846c6e00-d731-11eb-853b-d4df828c4e45.png">

The project was moved to https://github.com/dotnet-outdated/dotnet-outdated

Updated the link and the description.