### PR TITLE
Fixed link (moved from Github to Gitlab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 
 ### Bot
 * [BotSharp](https://github.com/SciSharp/BotSharp) - The Open Source AI Chatbot Platform Builder in 100% C# Running in .NET Core with Machine Learning algorithm.
+* [NadekoBot](https://gitlab.com/Kwoth/nadekobot) - Open source, general-purpose Discord chat bot written in C#.
 * [Telegram.Bot](https://github.com/TelegramBots/Telegram.Bot) - C# Telegram Bot API library.
 * [Funogram](https://github.com/Dolfik1/Funogram) - F# Telegram Bot Api library.
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,6 @@ Follows best practices and conventions to provide you a SOLID development experi
 
 ### Bot
 * [BotSharp](https://github.com/SciSharp/BotSharp) - The Open Source AI Chatbot Platform Builder in 100% C# Running in .NET Core with Machine Learning algorithm.
-* [NadekoBot](https://github.com/Kwoth/NadekoBot) - Open source, general-purpose Discord chat bot written in C#.
 * [Telegram.Bot](https://github.com/TelegramBots/Telegram.Bot) - C# Telegram Bot API library.
 * [Funogram](https://github.com/Dolfik1/Funogram) - F# Telegram Bot Api library.
 


### PR DESCRIPTION
404 page not found for NadekoBot (https://github.com/Kwoth/NadekoBot) 

Edit: Moved to Gitlab (https://gitlab.com/Kwoth/nadekobot)