### PR TITLE
Added link of ASP.NET Core Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,6 +832,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 
 ## Roadmaps
 * [ASP.NET Core Developer Roadmap](https://github.com/MoienTajik/AspNetCore-Developer-Roadmap) - Roadmap to becoming an ASP.NET Core developer in 2019.
+* [ASP.NET Core Developer Roadmap](https://roadmap.sh/aspnet-core) - Complete guide in becoming an ASP.NET Core Developer.
 
 ## Starter Kits
 * [Arch](https://github.com/Arch) - The collection of .NET Core libraries that are created by software architects who embrace all the new stuff in .NET Core.


### PR DESCRIPTION
Hi @thangchung,

I came across your repository [awesome-dotnet-core](https://github.com/thangchung/awesome-dotnet-core) and found it to be a valuable resource for ASP.NET enthusiasts.

While browsing through the repository, I noticed that it was missing link to a well structured guide such as the famous ["ASP.NET Core Developer Roadmap"](https://roadmap.sh/aspnet-core). I took the initiative to submit a ["Pull Request"](https://github.com/thangchung/awesome-dotnet-core/pull/830) adding it in Roadmaps section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz