### PR TITLE
Add Microsoft's ".NET for Java developers" eBook

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,6 +930,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 
 ## Books
 * [.NET Core in Action](https://manning.com/books/dotnet-core-in-action)
+* [.NET for Java developers](https://dotnet.microsoft.com/en-us/campaigns/dotnet-for-java-developers)
 * [ASP.NET Core Application Development: Building an application in four sprints (Developer Reference)](https://www.amazon.com/ASP-NET-Core-Application-Development-application/dp/1509304061)
 * [ASP.NET Core in Action](https://www.manning.com/books/asp-net-core-in-action)
 * [ASP.NET Core 1.0 High Performance](https://www.amazon.com/ASP-NET-Core-1-0-High-Performance/dp/1785881892)


### PR DESCRIPTION
Add a link to https://dotnet.microsoft.com/en-us/campaigns/dotnet-for-java-developers, Microsoft's free ".NET for Java developers" eBook.

This eBook is intended to offer a quick introduction to C# and .NET Core for those experienced in the Java ecosystem. The link I'm adding is to their landing page for the book and Microsoft has a download link on that landing page, thankfully one that does not ask for contact information before offering the free eBook.