### PR TITLE
Add Quantities

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 * [StrongGrid](https://github.com/Jericho/StrongGrid) - Client for SendGrid's v3 API. Not only allows you to send emails, but also allows you to bulk import contacts, manage lists and segments, create custom fields for your lists, etc. Also includes a parser for SendGrid Webhooks.
 
 ### Mathematics
+* [Quantities](https://github.com/atmoos/Quantities) - Enables type-safe and efficient handling of physical quantities supporting a broad set of units of measurements.
 * [UnitConversion](https://github.com/Stratajet/UnitConversion) - Expansible Unit Conversion Library for .NET Core and .NET Framework.
 * [AutoDiff](https://github.com/alexshtf/autodiff) - A library that provides fast, accurate and automatic differentiation (computes derivative / gradient) of mathematical functions.
 


### PR DESCRIPTION
Add the new library [Quantities](https://github.com/atmoos/Quantities) to the `Mathematics` section.

This library enables type-safe and efficient handling of quantities. It includes many pre-defined units and _all_ unit-prefixes. Additionally, it allows third parties to define their own units if needed. It is fast as well as memory efficient.

Quantities is based on the [international system of units](https://en.wikipedia.org/wiki/International_System_of_Units) (SI), but also supports many other units, such as imperial units.