### PR TITLE
Add Agentic Architect — Cursor persistence for .NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 * [WinApi](https://github.com/prasannavl/WinApi) - A simple, direct, ultra-thin CLR library for high-performance Win32 Native Interop with automation, windowing, DirectX, OpenGL and Skia helpers.
 
 ### IDE
-* [Agentic Architect](https://github.com/agenticstandardcontact-byte/agentic-architect) - Cursor \.mdc\ persistence framework and Learning Log protocol for senior C#/.NET teams.
+* [Agentic Architect](https://github.com/agenticstandardcontact-byte/agentic-architect) - Cursor `.mdc` persistence framework and Learning Log protocol for senior C#/.NET teams.
 * [Mono](https://github.com/mono/monodevelop) - MonoDevelop enables developers to quickly write desktop and web applications on Linux, Windows and Mac OS X. It also makes it easy for developers to port .NET applications created with Visual Studio to Linux and Mac OS X maintaining a single code base for all platforms.
 * [rider](https://www.jetbrains.com/rider/) - Cross-platform C# IDE based on the IntelliJ platform and ReSharper.
 * [Omnisharp](http://www.omnisharp.net/) - Family of Open Source projects, each with one goal: To enable a great .NET experience in YOUR editor of choice.

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 * [WinApi](https://github.com/prasannavl/WinApi) - A simple, direct, ultra-thin CLR library for high-performance Win32 Native Interop with automation, windowing, DirectX, OpenGL and Skia helpers.
 
 ### IDE
-* [Agentic Architect](https://github.com/agenticstandardcontact-byte/agentic-architect) - Cursor .mdc persistence framework and Learning Log protocol for senior C#/.NET teams.
+* [Agentic Architect](https://github.com/agenticstandardcontact-byte/agentic-architect) - Cursor \.mdc\ persistence framework and Learning Log protocol for senior C#/.NET teams.
 * [Mono](https://github.com/mono/monodevelop) - MonoDevelop enables developers to quickly write desktop and web applications on Linux, Windows and Mac OS X. It also makes it easy for developers to port .NET applications created with Visual Studio to Linux and Mac OS X maintaining a single code base for all platforms.
 * [rider](https://www.jetbrains.com/rider/) - Cross-platform C# IDE based on the IntelliJ platform and ReSharper.
 * [Omnisharp](http://www.omnisharp.net/) - Family of Open Source projects, each with one goal: To enable a great .NET experience in YOUR editor of choice.

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 * [WinApi](https://github.com/prasannavl/WinApi) - A simple, direct, ultra-thin CLR library for high-performance Win32 Native Interop with automation, windowing, DirectX, OpenGL and Skia helpers.
 
 ### IDE
-* [Agentic Architect](https://github.com/agenticstandardcontact-byte/agentic-architect) - Cursor `.mdc` persistence framework and Learning Log protocol for senior C#/.NET teams.
+* [Agentic Architect](https://github.com/agenticstandardcontact-byte/agentic-architect) - Cursor .mdc persistence framework and Learning Log protocol for senior C#/.NET teams.
 * [Mono](https://github.com/mono/monodevelop) - MonoDevelop enables developers to quickly write desktop and web applications on Linux, Windows and Mac OS X. It also makes it easy for developers to port .NET applications created with Visual Studio to Linux and Mac OS X maintaining a single code base for all platforms.
 * [rider](https://www.jetbrains.com/rider/) - Cross-platform C# IDE based on the IntelliJ platform and ReSharper.
 * [Omnisharp](http://www.omnisharp.net/) - Family of Open Source projects, each with one goal: To enable a great .NET experience in YOUR editor of choice.

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ Follows best practices and conventions to provide you a SOLID development experi
 * [WinApi](https://github.com/prasannavl/WinApi) - A simple, direct, ultra-thin CLR library for high-performance Win32 Native Interop with automation, windowing, DirectX, OpenGL and Skia helpers.
 
 ### IDE
+* [Agentic Architect](https://github.com/agenticstandardcontact-byte/agentic-architect) - Cursor `.mdc` persistence framework and Learning Log protocol for senior C#/.NET teams.
 * [Mono](https://github.com/mono/monodevelop) - MonoDevelop enables developers to quickly write desktop and web applications on Linux, Windows and Mac OS X. It also makes it easy for developers to port .NET applications created with Visual Studio to Linux and Mac OS X maintaining a single code base for all platforms.
 * [rider](https://www.jetbrains.com/rider/) - Cross-platform C# IDE based on the IntelliJ platform and ReSharper.
 * [Omnisharp](http://www.omnisharp.net/) - Family of Open Source projects, each with one goal: To enable a great .NET experience in YOUR editor of choice.


### PR DESCRIPTION
## Summary

Adds [Agentic Architect](https://github.com/agenticstandardcontact-byte/agentic-architect) — an open-source Cursor persistence framework for senior C#/.NET teams.

## What it provides

- Directory-scoped `.mdc` rules (SOLID boundaries, DI lifetime checks, hallucination circuit-breaker, session persistence)
- A `LEARNING_LOG.md` protocol so architectural context survives across Cursor sessions
- Free sample rule at `.cursor/rules/arch-core-lite.mdc` (MIT)

## Why include it

Fills a gap for **.NET-specific Cursor configuration** — most awesome-list AI entries are model SDKs or general LLM libraries, not IDE persistence for production C# codebases.

## Links

- Repository: https://github.com/agenticstandardcontact-byte/agentic-architect
- Site: https://agenticstandardcontact-byte.github.io/agentic-architect/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Agentic Architect to the IDE tools section of the README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thangchung/awesome-dotnet-core/pull/925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->